### PR TITLE
sprungebob squarepaste

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,9 @@ Or, if you want to use my `use-package' macro:
         :init
         (bind-key "C-y" 'erc-yank erc-mode-map)))
 
-This module requires gist.el, from: https://github.com/defunkt/gist.el
+If you want to use github instead of sprunge.us, install gist.el
+from https://github.com/defunkt/gist.el and add
+
+    (require 'gist)
+    (setq erc-yank-gisting-function 'erc-yank-gh-gist-region)
+


### PR DESCRIPTION
This change defaults to using sprunge.us and makes gist.el optional (might lower the barrier for installing if no non-optional dependencies).

OTOH it requires curl since I haven't bothered figuring out how to do that in elisp. 
